### PR TITLE
Fix util.go based on the tests

### DIFF
--- a/util.go
+++ b/util.go
@@ -3,8 +3,13 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 )
+
+func main() {
+
+}
 
 // FlattenJson takes in a  nested JSON as a byte array and a delimiter and returns an
 // exploded/flattened json byte array
@@ -108,6 +113,8 @@ func explodeMap(m map[string]interface{}, parent string, delimiter string) (map[
 	for k, i := range m {
 		if len(parent) > 0 {
 			k = parent + delimiter + k
+		} else {
+			k = delimiter + k
 		}
 		switch v := i.(type) {
 		case nil:
@@ -121,14 +128,15 @@ func explodeMap(m map[string]interface{}, parent string, delimiter string) (map[
 		case bool:
 			j[k] = v
 		case []interface{}:
-			out := make(map[string]interface{})
-			out, err = explodeList(v, k, delimiter)
+
+			tmp, err := json.Marshal(v)
+
 			if err != nil {
 				return nil, err
 			}
-			for key, value := range out {
-				j[key] = value
-			}
+
+			j[k] = fmt.Sprintf("%s", tmp)
+
 		case map[string]interface{}:
 			out := make(map[string]interface{})
 			out, err = explodeMap(v, k, delimiter)

--- a/util_test.go
+++ b/util_test.go
@@ -71,11 +71,12 @@ func (s *TestUtilSuite) TestExplodeMapJson1(c *C) {
 		"/age":            "23",
 		"/like_chocolate": "false",
 	}
+
 	res, err := explodeMap(s.map1, "", "/")
 	c.Assert(err, IsNil)
 	for k, v := range expected {
 		_, key_exists := res[k]
-		c.Assert(key_exists, Equals, true)
+		c.Assert(key_exists, Equals, true, Commentf("key: %#v, not found on res", k))
 		c.Assert(fmt.Sprint(res[k]), Equals, v, Commentf("for k: %#v, result should be: %#v", k, v))
 	}
 }
@@ -99,7 +100,7 @@ func (s *TestUtilSuite) TestExplodeMapJson2(c *C) {
 	c.Assert(err, IsNil)
 	for k, v := range expected {
 		_, key_exists := res[k]
-		c.Assert(key_exists, Equals, true)
-		c.Assert(fmt.Sprint(res[k]), Equals, v, Commentf("for k: %#v, result should be: %#v", k, v))
+		c.Assert(key_exists, Equals, true, Commentf("key: %#v, not found on res ... %#v", k, res))
+		c.Assert(fmt.Sprint(res[k]), Equals, v, Commentf("for k: %#v, result should be: %#v ... %#v", k, v, res[k]))
 	}
 }


### PR DESCRIPTION
- Add the right delimiter on explodeList function

- For a list, outputs the json of the list itself instead of add a key for each individual value. 

@wricardo 