### PR TITLE
Add keys option to import to print imported keys

### DIFF
--- a/src/json2confd/cmd_import.go
+++ b/src/json2confd/cmd_import.go
@@ -32,10 +32,16 @@ var cmdImport cli.Command = cli.Command{
 			Value: "",
 			Usage: "address and port of the backend. ex: 127.0.0.1:6379",
 		},
+		cli.StringFlag{
+			Name:  "keys",
+			Value: "false",
+			Usage: "print the imported keys from the source file (possible values: true/false)",
+		},
 	},
 	Usage: "Import the json into the specified backend",
 	Action: func(c *cli.Context) {
 		var err error
+		var keys []string
 		var importer Importer
 		var reader io.Reader
 		var flat map[string]interface{}
@@ -52,9 +58,14 @@ var cmdImport cli.Command = cli.Command{
 			log.Fatal(err)
 		}
 
-		if err = importer.Import(flat); err != nil {
+		if err, keys = importer.Import(flat); err != nil {
 			log.Fatal(err)
 		}
+
+		if c.String("keys") == "true" {
+			fmt.Println(beautifyKeys(keys))
+		}
+
 		fmt.Printf("Success! Imported %v entries into %s(%s)\n", len(flat), c.String("backend"), c.String("node"))
 	},
 }

--- a/src/json2confd/importer.go
+++ b/src/json2confd/importer.go
@@ -17,7 +17,7 @@ var IMPORTERS_PORTS map[string]string = map[string]string{
 type ImporterConstructors map[string]func(*cli.Context) Importer
 
 type Importer interface {
-	Import(map[string]interface{}) error
+	Import(map[string]interface{}) (err error, keys []string)
 }
 
 func ConstructImporter(c *cli.Context, importers ImporterConstructors) (Importer, error) {

--- a/src/json2confd/redis_importer.go
+++ b/src/json2confd/redis_importer.go
@@ -37,19 +37,26 @@ type RedisImporter struct {
 	prefix string
 }
 
-func (r RedisImporter) Import(p map[string]interface{}) error {
+func (r RedisImporter) Import(p map[string]interface{}) (err error, keys []string) {
+	err = nil
+
 	prefix := ""
 	if len(r.prefix) > 0 && r.prefix != "/" {
 		prefix = "/" + strings.TrimSpace(strings.Trim(r.prefix, "/"))
 	}
 
+	keys = make([]string, len(p))
+	i := 0
+
 	for k, v := range p {
 		_, err := r.pool.Get().Do("SET", prefix+k, fmt.Sprint(v))
 		if err != nil {
-			return err
+			return err, nil
 		}
 
+		keys[i] = k
+		i++
 	}
 
-	return nil
+	return
 }

--- a/src/json2confd/util.go
+++ b/src/json2confd/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -144,4 +145,15 @@ func ensurePort(address string, backend string) string {
 		}
 	}
 	return address
+}
+
+func beautifyKeys(keys []string) (ret string) {
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		ret += fmt.Sprintf("\t%q,\n", k)
+	}
+
+	return "\nkeys = [\n" + ret + "]\n"
 }


### PR DESCRIPTION
Added -keys option into "import" to print the imported keys

Usage: 
```
./json2confd import -file file.json -backend redis -node 127.0.0.1:6379 -keys true
```

and it should print something like:
```
keys = [
        "/key1/subkey1.1",
        "/key1/subkey1.2",
        "/key2",
        "/key3/subkey3.1",
]

Success! Imported 4 entries into redis(127.0.0.1:6379)
```

@wricardo 