### PR TITLE
Add "keys" command to output the keys to import

### DIFF
--- a/src/json2confd/cmd_keys.go
+++ b/src/json2confd/cmd_keys.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"github.com/codegangsta/cli"
+	"io"
+	"os"
 )
 
 var cmdKeys cli.Command = cli.Command{
@@ -21,20 +23,32 @@ var cmdKeys cli.Command = cli.Command{
 	Usage: "Output the keys to be imported",
 	Action: func(c *cli.Context) {
 
-		if file_map, err := jsonToMap(c.String("file")); err != nil {
-			panic(err)
+		var reader io.Reader
+		var err error
+
+		if reader, err = os.Open(c.String("file")); err != nil {
+			// TODO :: outputs the error to the io.Writer
 		} else {
-			le := len(file_map)
-			keys := make([]string, 0, le)
-			for k := range file_map {
-				keys = append(keys, k)
-			}
 
-			output := OutputData{
-				Keys: keys,
-			}
+			if file_map, err := jsonToMap(reader); err != nil {
+				// TODO :: outputs the error to the io.Writer
+			} else {
+				keys := make([]string, len(file_map))
+				i := 0
+				for k := range file_map {
+					keys[i] = k
+					i = i + 1
+				}
 
-			Output(output, c.String("output"))
+				output := OutputData{
+					Keys: keys,
+				}
+
+				if err := Output(output, c.String("output")); err != nil {
+					// TODO :: outputs the error to the io.Writer
+
+				}
+			}
 		}
 
 	},

--- a/src/json2confd/cmd_keys.go
+++ b/src/json2confd/cmd_keys.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+var cmdKeys cli.Command = cli.Command{
+	Name: "keys",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "file",
+			Value: "",
+			Usage: "json file to import. (if empty stdin will be used)",
+		},
+		cli.StringFlag{
+			Name:  "output",
+			Value: "json",
+			Usage: "output format: json",
+		},
+	},
+	Usage: "Output the keys to be imported",
+	Action: func(c *cli.Context) {
+
+		if file_map, err := jsonToMap(c.String("file")); err != nil {
+			panic(err)
+		} else {
+			le := len(file_map)
+			keys := make([]string, 0, le)
+			for k := range file_map {
+				keys = append(keys, k)
+			}
+
+			output := OutputData{
+				Keys: keys,
+			}
+
+			Output(output, c.String("output"))
+		}
+
+	},
+}

--- a/src/json2confd/main.go
+++ b/src/json2confd/main.go
@@ -12,6 +12,7 @@ func main() {
 	app.Usage = ""
 	app.Commands = []cli.Command{
 		cmdImport,
+		cmdKeys,
 	}
 
 	app.Run(os.Args)

--- a/src/json2confd/output.go
+++ b/src/json2confd/output.go
@@ -9,17 +9,22 @@ type OutputData struct {
 	Keys []string `json:"keys"`
 }
 
-func Output(data OutputData, outputFormat string) {
+func Output(data OutputData, outputFormat string) (err error) {
 	switch outputFormat {
 	case "json":
-		outputJson(data)
+		err = outputJson(data)
 	}
+
+	return
 }
 
-func outputJson(data OutputData) {
+func outputJson(data OutputData) error {
 	if retJson, err := json.Marshal(data); err != nil {
-		panic(err)
+		return err
 	} else {
+		// TODO :: outputs to the io.Writer
 		fmt.Printf("%s\n", retJson)
 	}
+
+	return nil
 }

--- a/src/json2confd/output.go
+++ b/src/json2confd/output.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type OutputData struct {
+	Keys []string `json:"keys"`
+}
+
+func Output(data OutputData, outputFormat string) {
+	switch outputFormat {
+	case "json":
+		outputJson(data)
+	}
+}
+
+func outputJson(data OutputData) {
+	if retJson, err := json.Marshal(data); err != nil {
+		panic(err)
+	} else {
+		fmt.Printf("%s\n", retJson)
+	}
+}

--- a/src/json2confd/util.go
+++ b/src/json2confd/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -144,4 +145,24 @@ func ensurePort(address string, backend string) string {
 		}
 	}
 	return address
+}
+
+func jsonToMap(file string) (flat map[string]interface{}, err error) {
+	var reader io.Reader
+
+	if reader, err = os.Open(file); err != nil {
+		return
+	}
+
+	if bytes, err := ioutil.ReadAll(reader); err != nil {
+		return nil, err
+	} else {
+
+		if flat, err = FlattenJson(bytes, "/"); err != nil {
+			return nil, err
+		} else {
+			return flat, nil
+		}
+	}
+
 }

--- a/src/json2confd/util.go
+++ b/src/json2confd/util.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -147,12 +146,7 @@ func ensurePort(address string, backend string) string {
 	return address
 }
 
-func jsonToMap(file string) (flat map[string]interface{}, err error) {
-	var reader io.Reader
-
-	if reader, err = os.Open(file); err != nil {
-		return
-	}
+func jsonToMap(reader io.Reader) (flat map[string]interface{}, err error) {
 
 	if bytes, err := ioutil.ReadAll(reader); err != nil {
 		return nil, err
@@ -164,5 +158,4 @@ func jsonToMap(file string) (flat map[string]interface{}, err error) {
 			return flat, nil
 		}
 	}
-
 }


### PR DESCRIPTION
Added **keys** option to output the keys to import from a file.

Usage:
```
./json2confd keys -file file.json -output json
```

and the output should be a json with the keys:
```
{"keys":["/key1","/key2","/key3", ... ,"/keyn"]}
```